### PR TITLE
[#65] 마이페이지 keyscreen 독서현황, 독서랭킹 연결

### DIFF
--- a/src/components/mypage/ReadingRanking.tsx
+++ b/src/components/mypage/ReadingRanking.tsx
@@ -15,66 +15,62 @@ const rankLabel: Record<number, string> = {
 function ReadingRanking() {
   return (
     <div className="bg-bg">
-      <main>
-        <header className="mb-3.5 flex justify-between">
-          <p className="text-title-02">독서 랭킹</p>
-          <button
-            type="button"
-            className="flex items-center gap-0.5 text-gray-500 text-body-03"
-          >
-            <span>전체보기</span>
-            <BackIcon className="rotate-180 w-[14px] h-[14px]" />
-          </button>
-        </header>
+      <header className="mb-3.5 flex justify-between">
+        <p className="text-title-02">독서 랭킹</p>
+        <button
+          type="button"
+          className="flex items-center gap-0.5 text-gray-500 text-body-03"
+        >
+          <span>전체보기</span>
+          <BackIcon className="rotate-180 w-[14px] h-[14px]" />
+        </button>
+      </header>
 
+      <section className="w-full mt-[14px]">
+        {/* 랭킹 리스트 */}
+        <div className="flex items-end justify-between">
+          {users.map((user) => {
+            const isFirst = user.rank === 1;
 
-        <section className="w-full mt-[14px]">
-          {/* 랭킹 리스트 */}
-          <div className="flex items-end justify-between">
-            {users.map((user) => {
-              const isFirst = user.rank === 1;
-
-              return (
-                <div key={user.name} className="flex flex-col items-center">
-                  {/* 이미지 + 랭크 뱃지 */}
-                  {isFirst ? (
-                    // 1등용: 그라데이션
-                    <div className="rounded-full p-[2px] [background-image:linear-gradient(330deg,_#788ade,_#E9EBF4)]">
-                      <div className="relative flex h-[90px] w-[90px] items-center justify-center rounded-full bg-gray-300">
-                        <span className="text-caption-01 text-gray-600">img</span>
-
-                        {/* 순위 뱃지 */}
-                        <div className="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 rounded-full bg-primary px-2 py-0.5 text-caption-02 text-white">
-                          {rankLabel[user.rank]}
-                        </div>
-                      </div>
-                    </div>
-                  ) : (
-                    // 나머지: 일반 원
-                    <div className="relative flex h-[70px] w-[70px] items-center justify-center rounded-full bg-gray-300">
+            return (
+              <div key={user.name} className="flex flex-col items-center">
+                {/* 이미지 + 랭크 뱃지 */}
+                {isFirst ? (
+                  // 1등용: 그라데이션
+                  <div className="rounded-full p-[2px] [background-image:linear-gradient(330deg,_#788ade,_#E9EBF4)]">
+                    <div className="relative flex h-[90px] w-[90px] items-center justify-center rounded-full bg-gray-300">
                       <span className="text-caption-01 text-gray-600">img</span>
-                      <div className="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 rounded-full bg-primary-side px-2 py-0.5 text-caption-02 text-white">
+
+                      {/* 순위 뱃지 */}
+                      <div className="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 rounded-full bg-primary px-2 py-0.5 text-caption-02 text-white">
                         {rankLabel[user.rank]}
                       </div>
                     </div>
-                  )}
+                  </div>
+                ) : (
+                  // 나머지: 일반 원
+                  <div className="relative flex h-[70px] w-[70px] items-center justify-center rounded-full bg-gray-300">
+                    <span className="text-caption-01 text-gray-600">img</span>
+                    <div className="absolute bottom-0 left-1/2 translate-y-1/2 -translate-x-1/2 rounded-full bg-primary-side px-2 py-0.5 text-caption-02 text-white">
+                      {rankLabel[user.rank]}
+                    </div>
+                  </div>
+                )}
 
-                  {/* 이름 */}
-                  <p className="mt-3 text-body-02">{user.name}</p>
+                {/* 이름 */}
+                <p className="mt-3 text-body-02">{user.name}</p>
 
-                  {/* 기록 */}
-                  <p className="mt-1 text-caption-02 text-gray-600">
-                    {user.books}권 읽음
-                    <span className="inline-block h-1 w-1 align-middle mx-1 rounded-full bg-gray-500/20" />
-                    {user.days}일 기록
-                  </p>
-                </div>
-              );
-            })}
-          </div>
-
-        </section>
-      </main>
+                {/* 기록 */}
+                <p className="mt-1 text-caption-02 text-gray-600">
+                  {user.books}권 읽음
+                  <span className="inline-block h-1 w-1 align-middle mx-1 rounded-full bg-gray-500/20" />
+                  {user.days}일 기록
+                </p>
+              </div>
+            );
+          })}
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/components/mypage/ReadingStatus.tsx
+++ b/src/components/mypage/ReadingStatus.tsx
@@ -2,45 +2,41 @@
 function ReadingStatus() {
   const tags = ["몽환적인", "사유적인, 묘사적인", "몰입도 높은"] as const;
   return (
-    <div className="bg-bg">
-      <main className="">
-        
-        {/* 제목 영역 */}
-        <header className="mb-3.5">
-          <p className="text-title-02">독서 현황</p>
-        </header>
+    <div className="bg-bg">        
+      {/* 제목 영역 */}
+      <header className="mb-3.5">
+        <p className="text-title-02">독서 현황</p>
+      </header>
 
-        {/* 내용 영역 */}
-        <section className="w-full bg-gray-100 rounded-lg p-4">
-          {/* subitle */}
-          <div className="flex justify-between items-center">
-            <div className="w-full text-subtitle-01-sb">이번 달 독서 현황 35%</div>
-            <div className="text-caption-01 bg-white justify-center rounded-full px-3 py-1 h-[25px]">11/31</div>
+      {/* 내용 영역 */}
+      <section className="w-full bg-gray-100 rounded-lg p-4">
+        {/* subitle */}
+        <div className="flex justify-between items-center">
+          <div className="w-full text-subtitle-01-sb">이번 달 독서 현황 35%</div>
+          <div className="text-caption-01 bg-white justify-center rounded-full px-3 py-1 h-[25px]">11/31</div>
+        </div>
+
+        {/* content */}
+        <div className="mt-2 mb-3">
+          <p className="text-caption-02 text-gray-600">몽환적인 묘사와 깊은 사유에 몰입해온 11일간의 여정.<br />Yoon님만의 선명한 문학적 취향을 완성해가고 있어요.</p>
+        </div>
+
+        {/* tag */}
+        <div>
+          <div className="flex flex-wrap gap-[6px]">
+            {tags.map((i) => {
+            return (
+              <button
+                key={i}
+                className="bg-lightblue-3 text-body-03 text-primary rounded-full px-[14px] py-[5px]"
+              >
+                {i}
+              </button>
+            );
+          })}
           </div>
-
-          {/* content */}
-          <div className="mt-2 mb-3">
-            <p className="text-caption-02 text-gray-600">몽환적인 묘사와 깊은 사유에 몰입해온 11일간의 여정.<br />Yoon님만의 선명한 문학적 취향을 완성해가고 있어요.</p>
-          </div>
-
-          {/* tag */}
-          <div>
-            <div className="flex flex-wrap gap-[6px]">
-              {tags.map((i) => {
-              return (
-                <button
-                  key={i}
-                  className="bg-lightblue-3 text-body-03 text-primary rounded-full px-[14px] py-[5px]"
-                >
-                  {i}
-                </button>
-              );
-            })}
-            </div>
-          </div>
-
-        </section>
-      </main>
+        </div>
+      </section>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -38,8 +38,7 @@
   /* 브랜드 컬러 */
   --color-primary: #3049c0;
   --color-primary-side: #788ade;
-  
-  --color-ligitblue: #E9EBF4;
+
   --color-lightblue-1: #e9ebf4;
   --color-lightblue-2: #e4e5f0;
   --color-lightblue-3: #788ADE26;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #65 

## 📝작업 내용
> 독서현황 연결
> 독서랭킹 연결 

### 스크린샷 (선택)
<img width="467" height="583" alt="image" src="https://github.com/user-attachments/assets/9e7230d4-59a5-4bc4-9670-9e9977d82bdf" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능

- 사용자 순위를 시각화하여 표시하는 읽기 순위 기능 추가 (1위 특별 배지 포함)
- 독서 진행률, 읽은 책 수, 기록된 날짜 등의 독서 통계를 표시하는 읽기 현황 섹션 추가
- 마이페이지 레이아웃 및 간격 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->