### PR TITLE
[#124] refactor: 독서 상태 type 재정의 및 독서 상태 판별 로직 최적화

### DIFF
--- a/src/constants/libraryTabs.ts
+++ b/src/constants/libraryTabs.ts
@@ -1,0 +1,8 @@
+import type { LibraryTab } from "../types/library";
+
+export const LIBRARY_TABS: { key: LibraryTab; label: string }[] = [
+    { key: "ALL", label: "전체" },
+    { key: "TO_READ", label: "읽을 예정" },
+    { key: "READING", label: "읽는 중" },
+    { key: "DONE", label: "완독" },
+];

--- a/src/data/myLibrary.mock.ts
+++ b/src/data/myLibrary.mock.ts
@@ -13,7 +13,7 @@ export const libraries: Library[] = [
         author: "a",
         publisher: "ㄱ",
         createdAt: "2020-01-01",
-        progress: 100,
+        progress: 10,
         CoverIcon: Dummy_book,
       },
       {
@@ -22,7 +22,7 @@ export const libraries: Library[] = [
         author: "b",
         publisher: "ㄴ",
         createdAt: "2021-01-01",
-        progress: 100,
+        progress: 30,
         CoverIcon: Dummy_book,
       },
       {

--- a/src/domain/BookStatus.ts
+++ b/src/domain/BookStatus.ts
@@ -1,0 +1,7 @@
+import type { BookStatus } from "../types/book.types";
+
+export function getBookStatusByProgress(progress: number): BookStatus {
+    if (progress === 0) return "TO_READ";
+    if (progress === 100) return "DONE";
+    return "READING";
+}

--- a/src/domain/Library.ts
+++ b/src/domain/Library.ts
@@ -1,0 +1,9 @@
+import type { BookStatus } from "../types/book.types";
+import type { LibraryTab } from "../types/library";
+
+export const TAB_TO_STATUSES: Record<LibraryTab, BookStatus[]> = {
+  ALL: ["TO_READ", "READING", "DONE"],
+  TO_READ: ["TO_READ"],
+  READING: ["READING"],
+  DONE: ["DONE"],
+};

--- a/src/pages/MyLibrary/EditBooksPage.tsx
+++ b/src/pages/MyLibrary/EditBooksPage.tsx
@@ -6,19 +6,9 @@ import { ConfirmModal } from "../../components/common/ConfirmModal"
 import { EditCheckBox } from "../../components/myLibrary/EditCheckBox"
 import EditBookCard from "../../components/myLibrary/EditBookCard"
 import { useToast } from "../../context/ToastContext"
-
-const TABS = [
-  { key: "ALL", label: "전체" },
-  { key: "WISHLIST", label: "읽을 예정" },
-  { key: "READING", label: "읽는 중" },
-  { key: "DONE", label: "완독" },
-];
-
-function getBookTabByProgress(progress: number): Exclude<LibraryTab, "ALL"> {
-  if (progress === 0) return "WISHLIST";
-  if (progress === 100) return "DONE";
-  return "READING";
-}
+import { LIBRARY_TABS } from "../../constants/libraryTabs"
+import { getBookStatusByProgress } from "../../domain/BookStatus"
+import { TAB_TO_STATUSES } from "../../domain/Library"
 
 export const EditBooksPage = ({ libraries }: { libraries: Library[] }) => {
 
@@ -44,19 +34,22 @@ export const EditBooksPage = ({ libraries }: { libraries: Library[] }) => {
     );
 
     const editableBooks = useMemo(() => {
-        if (library.name === "전체 도서") return library.books;
-        if (!activeTab || activeTab === "ALL") return library.books;
+        if (!library) return [];
 
-        return library.books.filter((book) => {
-            const tab = getBookTabByProgress(book.progress);
-            return tab === activeTab;
-        });
+        if (library.name === "전체 도서") return library.books;
+
+        const statuses = TAB_TO_STATUSES[activeTab ?? "ALL"];
+
+        return library.books.filter((book) =>
+            statuses.includes(getBookStatusByProgress(book.progress))
+        );
     }, [library, activeTab]);
+
 
     const activeTabLabel = useMemo(() => {
         if (!activeTab || activeTab === "ALL") return "전체";
 
-        return TABS.find(tab => tab.key === activeTab)?.label ?? "";
+        return LIBRARY_TABS.find(tab => tab.key === activeTab)?.label ?? "";
     }, [activeTab]);
 
 

--- a/src/pages/MyLibrary/MyLibraryDetailPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryDetailPage.tsx
@@ -8,19 +8,9 @@ import { BOOK_ORDER, sortOptions } from "../../enum/book";
 import { SortDropDown } from "../../components/common/dropdown/SortDropDown";
 import { LibraryActionDropDown, type LibraryAction } from "../../components/common/dropdown/LibraryActionDropDown";
 import { sortBooks } from "../../utils/sortBooks";
-
-const TABS = [
-  { key: "ALL", label: "전체" },
-  { key: "WISHLIST", label: "읽을 예정" },
-  { key: "READING", label: "읽는 중" },
-  { key: "DONE", label: "완독" },
-];
-
-function getBookTabByProgress(progress: number): Exclude<LibraryTab, "ALL"> {
-  if (progress === 0) return "WISHLIST";
-  if (progress === 100) return "DONE";
-  return "READING";
-}
+import { LIBRARY_TABS } from "../../constants/libraryTabs";
+import { TAB_TO_STATUSES } from "../../domain/Library";
+import { getBookStatusByProgress } from "../../domain/BookStatus";
 
 export function MyLibraryDetail({ libraries }: { libraries: Library[] }) {
 
@@ -57,13 +47,16 @@ export function MyLibraryDetail({ libraries }: { libraries: Library[] }) {
   ];
 
   const filteredBooks = useMemo(() => {
-    if (activeTab === "ALL") return library?.books;
+    if (!library) return [];
 
-    return library?.books.filter((book) => {
-      const tab = getBookTabByProgress(book.progress);
-      return tab === activeTab;
+    const allowedStatuses = TAB_TO_STATUSES[activeTab];
+
+    return library.books.filter((book) => {
+      const status = getBookStatusByProgress(book.progress);
+      return allowedStatuses.includes(status);
     });
-  }, [activeTab, library?.books]);
+  }, [activeTab, library]);
+
 
   const sortedBooks = useMemo(() => {
     if (!filteredBooks) return [];
@@ -98,7 +91,7 @@ export function MyLibraryDetail({ libraries }: { libraries: Library[] }) {
             )}
         </div>
         <div className="flex px-5 pt-3 items-end gap-3 self-stretch border-b border-gray-200">
-          {TABS.map((tab) => (
+          {LIBRARY_TABS.map((tab) => (
             <button
               key={tab.key}
               onClick={() => setActiveTab(tab.key as LibraryTab)}

--- a/src/types/book.types.ts
+++ b/src/types/book.types.ts
@@ -19,3 +19,5 @@ export type Author = {
   imageUrl?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
   books?: Book[];        
 };
+
+export type BookStatus = "TO_READ" | "READING" | "DONE" | "STOPPED";

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -8,4 +8,4 @@ export type Library = {
   sort: BOOK_ORDER;
 };
 
-export type LibraryTab = "ALL" | "WISHLIST" | "READING" | "DONE";
+export type LibraryTab = "ALL" | "TO_READ" | "READING" | "DONE";


### PR DESCRIPTION
## #️⃣연관된 이슈
> #124 

## 📝작업 내용
> swagger에 맞게 독서 상태 타입 재정의
> 독서 상태에 따른 서재 tab 배정 로직 리팩토링

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **변경사항**
  * 라이브러리 탭 명칭이 변경되었습니다: "위시리스트"에서 "읽을 책"으로 업데이트되었습니다.
  * 도서 상태 관리 시스템이 개선되어 필터링 및 탭 기능이 더욱 안정적으로 동작합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->