### PR TITLE
[#129] refactor: 서재 key screen 정렬 수정

### DIFF
--- a/src/data/myLibrary.mock.ts
+++ b/src/data/myLibrary.mock.ts
@@ -67,7 +67,8 @@ export const libraries: Library[] = [
         createdAt: "2021-01-01",
         progress: 2,
         CoverIcon: Dummy_book,
-      },],
+      },
+    ],
     sort: BOOK_ORDER.LATEST,
   },
   {

--- a/src/pages/MyLibrary/MyLibraryPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryPage.tsx
@@ -38,6 +38,7 @@ export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
                             </div>
                         )) : (
                             <div className="relative flex w-[375px] px-5 flex-col items-center gap-[10px]">
+                                <div className="h-[168px] self-stretch">
                                 <div className="inline-flex items-center gap-[10px]">
                                     {library.books.slice(0, 3).map((book) => (
                                         <div className="flex w-[104px] h-[156px] items-center rounded-[4px]">
@@ -56,10 +57,11 @@ export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
                                         </div>
                                     ))}
                                 </div>
+                                </div>
                                 <div className="absolute top-[116px] flex w-[347px] h-[52px] justify-center items-center">
                                     <GradationFrame/>
                                 </div>
-                                <div className="flex items-center gap-[10px]">
+                                <div className="flex items-center gap-[10px] self-stretch">
                                     {library.books.slice(0, 3).map((book) => (
                                         <div className="flex w-[104px] flex-col justify-center items-start gap-[2px]">
                                             <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">{book.title}</p>


### PR DESCRIPTION
## #️⃣연관된 이슈
> #129

## 📝작업 내용
> 서재페이지 key screen 도서 정렬 수정

### 스크린샷 (선택)
<img width="275" height="220" alt="image" src="https://github.com/user-attachments/assets/f8da2154-32d4-4485-8fee-e9e3a515b6df" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **스타일 개선**
  * My Library 페이지의 도서 표지 섹션 레이아웃을 최적화하여 더 나은 시각적 구성을 제공합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->