### PR TITLE
[#133] feat: 서제 페이지 key screen API 연동

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.18",
+    "@tanstack/react-query": "^5.90.20",
     "axios": "^1.13.2",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.18
         version: 4.1.18(vite@7.3.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2))
+      '@tanstack/react-query':
+        specifier: ^5.90.20
+        version: 5.90.20(react@19.2.3)
       axios:
         specifier: ^1.13.2
         version: 1.13.2
@@ -687,6 +690,14 @@ packages:
     resolution: {integrity: sha512-jVA+/UpKL1vRLg6Hkao5jldawNmRo7mQYrZtNHMIVpLfLhDml5nMRUo/8MwoX2vNXvnaXNNMedrMfMugAVX1nA==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
+
+  '@tanstack/query-core@5.90.20':
+    resolution: {integrity: sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==}
+
+  '@tanstack/react-query@5.90.20':
+    resolution: {integrity: sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -2173,6 +2184,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.18
       tailwindcss: 4.1.18
       vite: 7.3.1(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)
+
+  '@tanstack/query-core@5.90.20': {}
+
+  '@tanstack/react-query@5.90.20(react@19.2.3)':
+    dependencies:
+      '@tanstack/query-core': 5.90.20
+      react: 19.2.3
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
         <Route path="/bookdetail" element={<BookDetail />} />
 
         {/* 3. 서재 */}
-        <Route path="/my-library" element={<MyLibraryPage libraries={libraries} />} />
+        <Route path="/my-library" element={<MyLibraryPage/>} />
         <Route
           path="/my-library/:libraryName"
           element={<MyLibraryDetail libraries={libraries} />}

--- a/src/api/shelf.ts
+++ b/src/api/shelf.ts
@@ -1,0 +1,9 @@
+import type { Shelf } from "../types/library";
+import { publicApi } from "./axiosConfig";
+
+export const getShelves = async (userId: number): Promise<Shelf[]> => {
+    const {data} = await publicApi.get("/api/v1/shelves", {
+        headers: {"X-USER-ID": userId}
+    });
+    return data;
+}

--- a/src/api/userBooks.ts
+++ b/src/api/userBooks.ts
@@ -1,0 +1,12 @@
+import { BOOK_ORDER } from "../enum/book"
+import type { BookStatus } from "../types/book.types";
+import type { ResponseUserBooksDto } from "../types/library"
+import { publicApi } from "./axiosConfig"
+
+export const getBookList = async(userId: number, shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST): Promise<ResponseUserBooksDto> => {
+    const {data} = await publicApi.get("/api/v1/user-books", {
+        headers: {"X-USER-ID": userId},
+        params: {shelfId, status, sort},
+    });
+    return data;
+}

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -1,0 +1,4 @@
+export const QUERY_KEY = {
+    books: "books",
+    shelves: "shelves"
+}

--- a/src/hooks/queries/useGetBookList.ts
+++ b/src/hooks/queries/useGetBookList.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+import { BOOK_ORDER } from "../../enum/book";
+import type { BookStatus } from "../../types/book.types";
+import { QUERY_KEY } from "../../constants/key";
+import { getBookList } from "../../api/userBooks";
+
+export function useGetBookList (userId: number, shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST) {
+    return useQuery({
+        queryKey: [QUERY_KEY.books, userId, shelfId, status, sort],
+        queryFn: () => getBookList(userId, shelfId, status, sort),
+    })
+}

--- a/src/hooks/queries/useGetShelves.ts
+++ b/src/hooks/queries/useGetShelves.ts
@@ -1,0 +1,25 @@
+import { useQuery } from "@tanstack/react-query";
+import { QUERY_KEY } from "../../constants/key";
+import { getShelves } from "../../api/shelf";
+import type { Shelf } from "../../types/library";
+import { BOOK_ORDER } from "../../enum/book";
+
+export function useGetShelves (userId: number) {
+    return useQuery({
+        queryKey: [QUERY_KEY.shelves, userId],
+        queryFn: () => getShelves(userId),
+        select: (shelves) => {
+            const allBooksShelf: Shelf = {
+                shelfId: -1,
+                name: "전체 도서",
+                isPublic: false,
+                setOrder: BOOK_ORDER.LATEST,
+                previewBooks: shelves
+                    .flatMap((shelf) => shelf.previewBooks)
+                    .filter((book, index, self) => index === self.findIndex((b) => b.bookId === book.bookId))
+                    .slice(0, 3),
+            };
+            return [allBooksShelf, ...shelves];
+        },
+    });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,15 +5,20 @@ import "./index.css";
 import App from "./App";
 import { AuthProvider } from "./context/AuthContext";
 import { ToastProvider } from "./context/ToastContext";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ToastProvider>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-        </AuthProvider>
-      </BrowserRouter>
-    </ToastProvider>
+    <QueryClientProvider client={queryClient}>
+      <ToastProvider>
+        <BrowserRouter>
+          <AuthProvider>
+            <App />
+          </AuthProvider>
+        </BrowserRouter>
+      </ToastProvider>
+    </QueryClientProvider>
   </StrictMode>
 );

--- a/src/pages/MyLibrary/MyLibraryPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryPage.tsx
@@ -42,7 +42,7 @@ export function MyLibraryPage () {
                                 <div className="h-[168px] self-stretch">
                                 <div className="inline-flex items-center gap-[10px]">
                                     {shelf.previewBooks.slice(0, 3).map((book) => (
-                                        <div className="flex w-[104px] h-[156px] items-center rounded-[4px]">
+                                        <div key={book.bookId} className="flex w-[104px] h-[156px] items-center rounded-[4px]">
                                             {book.thumbnailUrl ? (
                                                 <img
                                                     src={book.thumbnailUrl}

--- a/src/pages/MyLibrary/MyLibraryPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryPage.tsx
@@ -2,10 +2,11 @@ import { useNavigate } from "react-router-dom"
 import { BackIcon } from "../../assets/icons"
 import { GradationFrame } from "../../components/myLibrary/GradationFrame"
 import NavbarBottom from "../../components/common/navbar/NavBarBottom"
-import type { Library } from "../../types/library"
+import { useGetShelves } from "../../hooks/queries/useGetShelves"
 
-export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
+export function MyLibraryPage () {
 
+    const { data: shelves = [] } = useGetShelves(1);
     const navigate = useNavigate();
     
     return (
@@ -14,19 +15,19 @@ export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
                 <p className="text-black text-head">내 서재</p>
             </div>
             <div className="flex flex-col w-[375px] items-start gap-7 mt-8">
-                {libraries.map((library) => (
-                    <div className="flex flex-col items-center gap-8 self-stretch">
+                {shelves.map((shelf) => (
+                    <div key={shelf.shelfId} className="flex flex-col items-center gap-8 self-stretch">
                         <div className="flex px-5 justify-between items-center self-stretch">
-                            <p className="text-black text-title-02">{library.name}</p>
+                            <p className="text-black text-title-02">{shelf.name}</p>
                             <button
                                 className="flex items-center gap-[2px]"
-                                onClick={() => navigate(`/my-library/${library.name}`)}
+                                onClick={() => navigate(`/my-library/${shelf.name}`)}
                             >
                                 <p className="text-body-03 text-gray-500 cursor-pointer">전체보기</p>
                                 <BackIcon className="w-[14px] h-[14px] rotate-180"/>
                             </button>
                         </div>
-                        {library.books.length === 0 ? ( library.name === "전체 도서" ? (
+                        {shelf.previewBooks.length === 0 ? ( shelf.shelfId === -1 ? (
                             <div className="flex flex-col items-center gap-[10px]">
                                 <p className="text-center text-gray-900 text-subtitle-01-sb">저장된 책이 없습니다.</p>
                                 <p className="text-center text-gray-600 text-body-03">먼저 읽고 있거나 읽고 싶은 책을 담아보세요.</p>
@@ -40,17 +41,15 @@ export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
                             <div className="relative flex w-[375px] px-5 flex-col items-center gap-[10px]">
                                 <div className="h-[168px] self-stretch">
                                 <div className="inline-flex items-center gap-[10px]">
-                                    {library.books.slice(0, 3).map((book) => (
+                                    {shelf.previewBooks.slice(0, 3).map((book) => (
                                         <div className="flex w-[104px] h-[156px] items-center rounded-[4px]">
-                                            {book.coverUrl ? (
+                                            {book.thumbnailUrl ? (
                                                 <img
-                                                    src={book.coverUrl}
+                                                    src={book.thumbnailUrl}
                                                     alt={book.title}
                                                     className="h-full w-full object-cover"
                                                     draggable={false}
                                                 />
-                                            ) : book.CoverIcon ? (
-                                                <book.CoverIcon className="h-full w-full" />
                                             ) : (
                                                 <span className="text-xs">No Image</span>
                                             )}
@@ -62,10 +61,10 @@ export function MyLibraryPage ({ libraries }: { libraries: Library[] }) {
                                     <GradationFrame/>
                                 </div>
                                 <div className="flex items-center gap-[10px] self-stretch">
-                                    {library.books.slice(0, 3).map((book) => (
+                                    {shelf.previewBooks.slice(0, 3).map((book) => (
                                         <div className="flex w-[104px] flex-col justify-center items-start gap-[2px]">
                                             <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">{book.title}</p>
-                                            <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">{book.author}, {book.publisher}</p>
+                                            <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">{book.authorName}, {book.publisherName}</p>
                                         </div>  
                                     ))}
                                 </div>

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -10,6 +10,22 @@ export type Library = {
 
 export type LibraryTab = "ALL" | "TO_READ" | "READING" | "DONE";
 
+export type PreviewBook = {
+  bookId: number;
+  title: string;
+  thumbnailUrl: string;
+  authorName: string;
+  publisherName: string;
+};
+
+export type Shelf = {
+  shelfId: number;
+  name: string;
+  isPublic: boolean;
+  setOrder: BOOK_ORDER;
+  previewBooks: PreviewBook[];
+}
+
 export type ResponseUserBooksDto = {
   userBookId: number;
   status: string;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #133

## 📝작업 내용
> 서제 페이지 key screen API 연동

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 도서관 페이지가 선반 기반으로 전환되어 선반별 도서 미리보기를 표시합니다.
  * "전체 도서" 선반이 자동 생성되어 모든 도서를 한곳에서 볼 수 있습니다.
  * 도서 및 선반 목록이 클라이언트에서 자동으로 페칭되어 실시간으로 반영됩니다.

* **Chores**
  * 데이터 페칭을 위한 React Query가 도입되어 로딩/캐시 동작을 개선했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->