### PR TITLE
[#145] 홈 지금읽고있는책 Frame 추가

### DIFF
--- a/src/assets/icons.ts
+++ b/src/assets/icons.ts
@@ -34,6 +34,7 @@ import ArrowRight from "./icons/ArrowRight.svg?react";
 import Vector from "./icons/Vector.svg?react";
 import Plus from "./icons/Plus.svg?react";
 import Bookmark from "./icons/bookmark.svg?react";
+import Frame from "./icons/Frame.svg?react"
 
 
 //특수 페이지 아이콘
@@ -69,7 +70,7 @@ export {
   Share, Search, Quit, Camera, Comment, Archive, 
   Report, Album, Pencil, Menu, CheckIcon, CheckIconWhite, Reset,
   Arrow, Setting, Kebab, ArrowDown, ArrowRight, Vector, Plus,
-  Bookmark,
+  Bookmark, Frame,
 
   Error, Loading, ErrorIcon,
 

--- a/src/assets/icons/Frame.svg
+++ b/src/assets/icons/Frame.svg
@@ -1,0 +1,30 @@
+<svg width="183" height="80" viewBox="0 0 183 80" fill="none" xmlns="http://www.w3.org/2000/svg">
+<foreignObject x="0" y="0" width="183" height="80"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(2px);clip-path:url(#bgblur_0_948_24657_clip_path);height:100%;width:100%"></div></foreignObject><g filter="url(#filter0_d_948_24657)" data-figma-bg-blur-radius="4">
+<path d="M16 10H167V52C167 55.3137 164.314 58 161 58H22C18.6863 58 16 55.3137 16 52V10Z" fill="url(#paint0_linear_948_24657)" fill-opacity="0.35" shape-rendering="crispEdges"/>
+<path d="M166.4 10.5996V52C166.4 54.9823 163.982 57.4004 161 57.4004H22C19.0177 57.4004 16.5996 54.9823 16.5996 52V10.5996H166.4Z" stroke="url(#paint1_linear_948_24657)" stroke-width="1.2" shape-rendering="crispEdges"/>
+</g>
+<defs>
+<filter id="filter0_d_948_24657" x="0" y="0" width="183" height="80" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="6"/>
+<feGaussianBlur stdDeviation="8"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.187016 0 0 0 0 0.285445 0 0 0 0 0.752984 0 0 0 0.15 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_948_24657"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_948_24657" result="shape"/>
+</filter>
+<clipPath id="bgblur_0_948_24657_clip_path" transform="translate(0 0)"><path d="M16 10H167V52C167 55.3137 164.314 58 161 58H22C18.6863 58 16 55.3137 16 52V10Z"/>
+</clipPath><linearGradient id="paint0_linear_948_24657" x1="92.5812" y1="10.7541" x2="100.153" y2="58.1904" gradientUnits="userSpaceOnUse">
+<stop stop-color="#3049C0" stop-opacity="0.8"/>
+<stop offset="0.4" stop-color="#788ADE" stop-opacity="0.8"/>
+<stop offset="0.6" stop-color="#788ADE" stop-opacity="0.9"/>
+<stop offset="1" stop-color="#3049C0"/>
+</linearGradient>
+<linearGradient id="paint1_linear_948_24657" x1="104.271" y1="10" x2="89.3119" y2="61.0984" gradientUnits="userSpaceOnUse">
+<stop stop-color="white" stop-opacity="0.7"/>
+<stop offset="0.5" stop-color="#3049C0" stop-opacity="0.5"/>
+<stop offset="1" stop-color="white" stop-opacity="0.5"/>
+</linearGradient>
+</defs>
+</svg>

--- a/src/components/home/CurrentReading.tsx
+++ b/src/components/home/CurrentReading.tsx
@@ -3,6 +3,7 @@ import Carousel from "react-multi-carousel";
 import type { CarouselInternalState } from "react-multi-carousel";
 import "react-multi-carousel/lib/styles.css";
 import { BOOKS } from "../../data/book.mock";
+import { Frame } from "../../assets/icons";
 
 const CurrentReading: React.FC = () => {
   const length = BOOKS.length;
@@ -92,23 +93,34 @@ const CurrentReading: React.FC = () => {
               >
                 <div
                   className={[
-                    "w-30 h-45 rounded-sm overflow-hidden",
+                    "relative w-30 h-45", 
                     "flex items-center justify-center",
                   ].join(" ")}
                 >
-                  {book.coverUrl ? (
-                    <img
-                      src={book.coverUrl}
-                      alt={book.title}
-                      className="h-full w-full object-cover"
-                      draggable={false}
-                    />
-                  ) : CoverIcon ? (
-                    <CoverIcon className="h-full w-full" />
-                  ) : (
-                    <span className="text-xs">No Image</span>
-                  )}
+                  <div className="w-full h-full rounded-sm overflow-hidden">
+                    {book.coverUrl ? (
+                      <img
+                        src={book.coverUrl}
+                        alt={book.title}
+                        className="w-full h-full object-cover"
+                        draggable={false}
+                      />
+                    ) : CoverIcon ? (
+                      <CoverIcon className="w-full h-full" />
+                    ) : (
+                      <span className="text-xs">No Image</span>
+                    )}
+                  </div>
+
+                  <Frame 
+                    className="pointer-events-none absolute bottom-0 right-0" 
+                    style={{ 
+                      transform: 'translateY(35px) translateX(31px)'
+                    }}
+                  />
                 </div>
+
+
 
                 {/* 책 정보 */}
                 {isCenter && (


### PR DESCRIPTION
## #️⃣연관된 이슈
> #145 

## 📝작업 내용
> 홈 지금읽고있는책 Frame 추가

### 스크린샷 (선택)

<img width="452" height="423" alt="image" src="https://github.com/user-attachments/assets/a2b2c7be-c205-430e-9c5f-a937c70cc1e0" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 현재 읽는 책의 표지에 프레임 시각 요소가 추가되었습니다. 새로운 프레임 아이콘이 각 책 표지의 우측 하단에 배치되어 책 커버 디스플레이를 개선합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->