### PR TITLE
[#154] feat: 서재 페이지 - 저장 도서 목록 조회 api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,14 @@ import BookPickPage from "./pages/booklog/BookPickPage";
 import BookWritePage from "./pages/booklog/BookWritePage";
 
 // 3. 서재
-import { MyLibraryPage } from "./pages/MyLibrary/MyLibraryPage";
+import { MyLibraryPage } from "./pages/myLibrary/MyLibraryPage";
 import { libraries } from "./data/myLibrary.mock";
-import { MyLibraryDetail } from "./pages/MyLibrary/MyLibraryDetailPage";
-import { EditBooksPage } from "./pages/MyLibrary/EditBooksPage";
-import AddLibraryPage from "./pages/MyLibrary/AddLibraryPage";
-import EditPage from "./pages/MyLibrary/EditPage";
-import RecordPage from "./pages/MyLibrary/RecordPage";
-import StoppedBooksPage from "./pages/MyLibrary/StoppedBooksPage";
+import { MyLibraryDetail } from "./pages/myLibrary/MyLibraryDetailPage";
+import { EditBooksPage } from "./pages/myLibrary/EditBooksPage";
+import AddLibraryPage from "./pages/myLibrary/AddLibraryPage";
+import EditPage from "./pages/myLibrary/EditPage";
+import RecordPage from "./pages/myLibrary/RecordPage";
+import StoppedBooksPage from "./pages/myLibrary/StoppedBooksPage";
 
 // 4. 마이페이지
 import MyPage from "./pages/mypage/MyPage";
@@ -94,10 +94,7 @@ function App() {
 
         {/* 3. 서재 */}
         <Route path="/my-library" element={<MyLibraryPage/>} />
-        <Route
-          path="/my-library/:libraryName"
-          element={<MyLibraryDetail libraries={libraries} />}
-        />
+        <Route path="/my-library/:shelfId" element={<MyLibraryDetail />} />
         <Route
           path="/my-library/:libraryName/edit-books"
           element={<EditBooksPage libraries={libraries} />}

--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,4 +1,6 @@
 import axios, { type AxiosInstance, type AxiosError, type AxiosResponse } from 'axios';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { LOCAL_STORAGE_KEY } from '../constants/key';
 
 // public Instance
 export const publicApi: AxiosInstance = axios.create({
@@ -8,6 +10,20 @@ export const publicApi: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
+
+publicApi.interceptors.request.use((config)=>{
+    // const {getItem} = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
+    // const accessToken = getItem();
+
+    // if(accessToken) {
+        config.headers = config.headers || {};
+        config.headers.Authorization = `Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Iiwicm9sZSI6IlJPTEVfVVNFUiIsImVtYWlsIjoidGVzdCIsImlhdCI6MTc2OTY4MDEwOSwiZXhwIjoxNzY5Njg3MzA5fQ.IrB6iVeAzBot7lEhFO4U58XiLVH2K4wGeCHt5Ul6uk2Zo-qwfaSn5nN52Jlc-XWgFrVDIgS2mbY_sNpTE48nYw`;
+    // }
+
+    return config;
+},
+(error) => Promise.reject(error),
+);
 
 // 공통 에러 인터셉터
 publicApi.interceptors.response.use(

--- a/src/api/axiosConfig.ts
+++ b/src/api/axiosConfig.ts
@@ -1,6 +1,4 @@
 import axios, { type AxiosInstance, type AxiosError, type AxiosResponse } from 'axios';
-import { useLocalStorage } from '../hooks/useLocalStorage';
-import { LOCAL_STORAGE_KEY } from '../constants/key';
 
 // public Instance
 export const publicApi: AxiosInstance = axios.create({
@@ -10,20 +8,6 @@ export const publicApi: AxiosInstance = axios.create({
     'Content-Type': 'application/json',
   },
 });
-
-publicApi.interceptors.request.use((config)=>{
-    // const {getItem} = useLocalStorage(LOCAL_STORAGE_KEY.accessToken);
-    // const accessToken = getItem();
-
-    // if(accessToken) {
-        config.headers = config.headers || {};
-        config.headers.Authorization = `Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0Iiwicm9sZSI6IlJPTEVfVVNFUiIsImVtYWlsIjoidGVzdCIsImlhdCI6MTc2OTY4MDEwOSwiZXhwIjoxNzY5Njg3MzA5fQ.IrB6iVeAzBot7lEhFO4U58XiLVH2K4wGeCHt5Ul6uk2Zo-qwfaSn5nN52Jlc-XWgFrVDIgS2mbY_sNpTE48nYw`;
-    // }
-
-    return config;
-},
-(error) => Promise.reject(error),
-);
 
 // 공통 에러 인터셉터
 publicApi.interceptors.response.use(

--- a/src/api/shelf.ts
+++ b/src/api/shelf.ts
@@ -1,9 +1,7 @@
 import type { Shelf } from "../types/library";
 import { publicApi } from "./axiosConfig";
 
-export const getShelves = async (userId: number): Promise<Shelf[]> => {
-    const {data} = await publicApi.get("/api/v1/shelves", {
-        headers: {"X-USER-ID": userId}
-    });
+export const getShelves = async (): Promise<Shelf[]> => {
+    const {data} = await publicApi.get("/api/v1/shelves");
     return data;
 }

--- a/src/api/userBooks.ts
+++ b/src/api/userBooks.ts
@@ -3,9 +3,8 @@ import type { BookStatus } from "../types/book.types";
 import type { ResponseUserBooksDto } from "../types/library"
 import { publicApi } from "./axiosConfig"
 
-export const getBookList = async(userId: number, shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST): Promise<ResponseUserBooksDto> => {
+export const getBookList = async(shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST): Promise<ResponseUserBooksDto> => {
     const {data} = await publicApi.get("/api/v1/user-books", {
-        headers: {"X-USER-ID": userId},
         params: {shelfId, status, sort},
     });
     return data;

--- a/src/components/myLibrary/BookCard.tsx
+++ b/src/components/myLibrary/BookCard.tsx
@@ -1,8 +1,8 @@
-import type { Book } from "../../types/book.types";
+import type { UserBook } from "../../types/library";
 
 type BookCardProps = {
-  book: Book;
-  onClick?: (book: Book) => void;
+  book: UserBook;
+  onClick?: (book: UserBook) => void;
 };
 
 export const BookCard = ({ book, onClick }: BookCardProps) => {
@@ -11,17 +11,13 @@ export const BookCard = ({ book, onClick }: BookCardProps) => {
       className="flex w-[104px] flex-col items-start gap-2 shrink-0"
       onClick={() => onClick?.(book)}
     >
-      {book.coverUrl ? (
+      {book.thumbnailUrl ? (
         <img
-          src={book.coverUrl}
+          src={book.thumbnailUrl}
           alt={book.title}
           className="w-[104px] h-[158.476px] aspect-[104.00/158.48] rounded-[4px] bg-gray-300 cursor-pointer"
           draggable={false}
         />
-      ) : book.CoverIcon ? (
-        <button type="button" className="cursor-pointer">
-          <book.CoverIcon className="w-[104px] h-[158.476px] aspect-[104.00/158.48] rounded-[4px]" />
-        </button>
       ) : (
         <button
           type="button"
@@ -36,7 +32,7 @@ export const BookCard = ({ book, onClick }: BookCardProps) => {
           {book.title}
         </p>
         <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">
-          {book.author}, {book.publisher}
+          {book.authorName}, {book.publisherName}
         </p>
       </div>
     </div>

--- a/src/components/myLibrary/ReadingBookCard.tsx
+++ b/src/components/myLibrary/ReadingBookCard.tsx
@@ -1,39 +1,37 @@
-import type { Book } from "../../types/book.types";
+import type { UserBook } from "../../types/library";
 
 type BookCardProps = {
-    book: Book;
+    book: UserBook;
 }
 
 export const ReadingBookCard = ({book}: BookCardProps) => {
     return (
         <div className="flex w-[104px] flex-col items-start gap-2 shrink-0">
-            {book.coverUrl ? (
+            {book.thumbnailUrl ? (
                 <img
-                    src={book.coverUrl}
+                    src={book.thumbnailUrl}
                     alt={book.title}
                     className="w-[104px] h-[159.059px] aspect-[104.00/159.06] rounded-[4px] bg-gray-300"
                     draggable={false}
                 />
-            ) : book.CoverIcon ? (
-                <book.CoverIcon className="w-[104px] h-[159.059px] aspect-[104.00/159.06] rounded-[4px]" />
             ) : (
                 <span className="w-[104px] h-[159.059px] aspect-[104.00/159.06] rounded-[4px] bg-gray-300 text-xs">No Image</span>
             )}
             <div className="flex w-[104px] flex-col items-start gap-[2px]">
                 <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">{book.title}</p>
-                <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">{book.author}, {book.publisher}</p>
+                <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">{book.authorName}, {book.publisherName}</p>
             </div>
             <div className="flex w-[104px] items-start gap-2">
                 <div className="flex w-[73px] items-center gap-[2px] shrink-0">
                     <div
                         className="h-[12px] shrink-0 rounded-[4px] bg-primary"
-                        style={{width: `${ (71 * book.progress) / 100}px`}}
+                        style={{width: `${ (71 * book.progressPercent) / 100}px`}}
                     />
                     <div
                         className="h-[12px] shrink-0 rounded-[4px] bg-[rgba(0,0,0,0.08)]"
-                        style={{width: `${(71 - ((71 * book.progress) / 100))}px`}}
+                        style={{width: `${(71 - ((71 * book.progressPercent) / 100))}px`}}
                     />
-                    <p className="text-black text-right text-en-caption-02">{book.progress}%</p>
+                    <p className="text-black text-right text-en-caption-02">{book.progressPercent}%</p>
                 </div>
             </div>
         </div>

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -1,3 +1,8 @@
+export const LOCAL_STORAGE_KEY = {
+    accessToken: "accessToken",
+    refreshToken: "refreshToken",
+}
+
 export const QUERY_KEY = {
     books: "books",
     shelves: "shelves"

--- a/src/constants/libraryTabs.ts
+++ b/src/constants/libraryTabs.ts
@@ -4,5 +4,5 @@ export const LIBRARY_TABS: { key: LibraryTab; label: string }[] = [
     { key: "ALL", label: "전체" },
     { key: "TO_READ", label: "읽을 예정" },
     { key: "READING", label: "읽는 중" },
-    { key: "DONE", label: "완독" },
+    { key: "COMPLETED", label: "완독" },
 ];

--- a/src/domain/BookStatus.ts
+++ b/src/domain/BookStatus.ts
@@ -2,6 +2,6 @@ import type { BookStatus } from "../types/book.types";
 
 export function getBookStatusByProgress(progress: number): BookStatus {
     if (progress === 0) return "TO_READ";
-    if (progress === 100) return "DONE";
+    if (progress === 100) return "COMPLETED";
     return "READING";
 }

--- a/src/domain/Library.ts
+++ b/src/domain/Library.ts
@@ -2,8 +2,8 @@ import type { BookStatus } from "../types/book.types";
 import type { LibraryTab } from "../types/library";
 
 export const TAB_TO_STATUSES: Record<LibraryTab, BookStatus[]> = {
-  ALL: ["TO_READ", "READING", "DONE"],
+  ALL: ["TO_READ", "READING", "COMPLETED"],
   TO_READ: ["TO_READ"],
   READING: ["READING"],
-  DONE: ["DONE"],
+  DONE: ["COMPLETED"],
 };

--- a/src/domain/Library.ts
+++ b/src/domain/Library.ts
@@ -5,5 +5,5 @@ export const TAB_TO_STATUSES: Record<LibraryTab, BookStatus[]> = {
   ALL: ["TO_READ", "READING", "COMPLETED"],
   TO_READ: ["TO_READ"],
   READING: ["READING"],
-  DONE: ["COMPLETED"],
+  COMPLETED: ["COMPLETED"],
 };

--- a/src/hooks/queries/useGetBookList.ts
+++ b/src/hooks/queries/useGetBookList.ts
@@ -4,9 +4,9 @@ import type { BookStatus } from "../../types/book.types";
 import { QUERY_KEY } from "../../constants/key";
 import { getBookList } from "../../api/userBooks";
 
-export function useGetBookList (userId: number, shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST) {
+export function useGetBookList (shelfId?: number, status?: BookStatus, sort: BOOK_ORDER = BOOK_ORDER.LATEST) {
     return useQuery({
-        queryKey: [QUERY_KEY.books, userId, shelfId, status, sort],
-        queryFn: () => getBookList(userId, shelfId, status, sort),
+        queryKey: [QUERY_KEY.books, shelfId, status, sort],
+        queryFn: () => getBookList(shelfId, status, sort),
     })
 }

--- a/src/hooks/queries/useGetShelves.ts
+++ b/src/hooks/queries/useGetShelves.ts
@@ -4,10 +4,10 @@ import { getShelves } from "../../api/shelf";
 import type { Shelf } from "../../types/library";
 import { BOOK_ORDER } from "../../enum/book";
 
-export function useGetShelves (userId: number) {
+export function useGetShelves () {
     return useQuery({
-        queryKey: [QUERY_KEY.shelves, userId],
-        queryFn: () => getShelves(userId),
+        queryKey: [QUERY_KEY.shelves],
+        queryFn: () => getShelves(),
         select: (shelves) => {
             const allBooksShelf: Shelf = {
                 shelfId: -1,

--- a/src/pages/MyLibrary/MyLibraryDetailPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryDetailPage.tsx
@@ -24,7 +24,7 @@ export function MyLibraryDetail() {
 
   const status = activeTab === "ALL" ? undefined : (activeTab as "TO_READ" | "READING" | "COMPLETED");
 
-  const { data: books, isLoading } = useGetBookList( parsedShelfId, status, sortOrder);
+  const { data: books } = useGetBookList( parsedShelfId, status, sortOrder);
   const bookItems = books?.items ?? [];
 
   const actions: LibraryAction[] = [

--- a/src/pages/MyLibrary/MyLibraryDetailPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryDetailPage.tsx
@@ -14,7 +14,8 @@ export function MyLibraryDetail() {
 
   const { shelfId } = useParams();
   const parsedShelfId = shelfId === "-1" ? undefined : Number(shelfId);
-  const shelfName = useLocation().state.shelfName;
+  const location  = useLocation();
+  const shelfName = location.state?.shelfName ?? "전체 서재";
   const navigate = useNavigate();
 
   const [activeTab, setActiveTab] = useState<LibraryTab>("ALL")

--- a/src/pages/MyLibrary/MyLibraryPage.tsx
+++ b/src/pages/MyLibrary/MyLibraryPage.tsx
@@ -5,7 +5,7 @@ import { useGetShelves } from "../../hooks/queries/useGetShelves"
 
 export function MyLibraryPage () {
 
-    const { data: shelves = [] } = useGetShelves(1);
+    const { data: shelves = [] } = useGetShelves();
     const navigate = useNavigate();
     const GradationFrame = "w-[347px] shrink-0 self-stretch rounded-b-[6px] border-[1.2px] border-[rgba(255,255,255,0.7)] bg-[linear-gradient(153deg,rgba(48,73,192,0.28)_18%,rgba(120,138,222,0.28)_44.99%,rgba(120,138,222,0.31)_58.48%,rgba(48,73,192,0.35)_85.47%)] shadow-[0_6px_16px_rgba(48,73,192,0.15)] backdrop-blur-[2px]"
     
@@ -21,7 +21,9 @@ export function MyLibraryPage () {
                             <p className="text-black text-title-02">{shelf.name}</p>
                             <button
                                 className="flex items-center gap-[2px]"
-                                onClick={() => navigate(`/my-library/${shelf.name}`)}
+                                onClick={() => navigate(`/my-library/${shelf.shelfId}`,{
+                                    state: { shelfName: shelf.name},
+                                })}
                             >
                                 <p className="text-body-03 text-gray-500 cursor-pointer">전체보기</p>
                                 <BackIcon className="w-[14px] h-[14px] rotate-180"/>

--- a/src/types/book.types.ts
+++ b/src/types/book.types.ts
@@ -20,4 +20,4 @@ export type Author = {
   books?: Book[];        
 };
 
-export type BookStatus = "TO_READ" | "READING" | "DONE" | "STOPPED";
+export type BookStatus = "TO_READ" | "READING" | "COMPLETED" | "STOPPED";

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -1,5 +1,5 @@
 import type { BOOK_ORDER } from "../enum/book";
-import type { Book } from "./book.types";
+import type { Book, BookStatus } from "./book.types";
 
 export type Library = {
   name: string;
@@ -26,13 +26,19 @@ export type Shelf = {
   previewBooks: PreviewBook[];
 }
 
-export type ResponseUserBooksDto = {
+export type UserBook = {
   userBookId: number;
-  status: string;
+  status: BookStatus;
   progressPercent: number;
   currentPage: number;
   bookId: number;
   title: string;
   thumbnailUrl: string;
   publisherName: string;
+  authorName: string;
 }
+
+export type ResponseUserBooksDto = {
+  totalCount: number;
+  items: UserBook[];
+};

--- a/src/types/library.ts
+++ b/src/types/library.ts
@@ -8,7 +8,7 @@ export type Library = {
   sort: BOOK_ORDER;
 };
 
-export type LibraryTab = "ALL" | "TO_READ" | "READING" | "DONE";
+export type LibraryTab = "ALL" | "TO_READ" | "READING" | "COMPLETED";
 
 export type PreviewBook = {
   bookId: number;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #154

## 📝작업 내용
> 서재 페이지 - 저장 도서 목록 조회 api 연결
> 저장 도서 type 정의

### 스크린샷 (선택)
<img width="304" height="626" alt="image" src="https://github.com/user-attachments/assets/6bce9c4e-1036-4e99-a7e4-0da3f5efdfb3" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 서재 항목으로 이동 시 식별 방식이 ID 기반으로 변경되어 더 일관된 네비게이션 제공

* **개선사항**
  * 도서 카드 UI 개선: 썸네일 우선 표시, 저자/출판사 이름 표기 업데이트
  * 읽기 진행 표시가 퍼센트 기반으로 표시되어 가독성 향상
  * 상태 명칭 정리: "완독" 표기로 통일
  * 서재 조회 및 목록 로딩 로직 단순화로 전반적 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->