### PR TITLE
[#235] fix: 소셜 로그인 리다이렉트 페이지에서 라우팅 수정

### DIFF
--- a/src/pages/KakaoLoginRedirectPage.tsx
+++ b/src/pages/KakaoLoginRedirectPage.tsx
@@ -7,7 +7,7 @@ export const KakaoLoginRedirectPage = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const { setTokens } = useAuth();
-  const { data: onboardingProfile, refetch } = useGetOnboardingProfile();
+  const { refetch } = useGetOnboardingProfile();
 
   useEffect(() => {
     const handleKakaoLogin = async () => {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #235

## 📝작업 내용
> 소셜 로그인 에러 수정

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 카카오 로그인 후 토큰 누락 시 적절한 오류 처리 및 로그인 페이지로 안전하게 리디렉션
  * 로그인 실패 시 보다 구체적인 오류 로깅 및 리디렉션 동작 개선

* **New Features**
  * 로그인 후 사용자 프로필 재조회(refetch)를 통한 상태 확인 및 스마트 라우팅 추가 — 온보딩 완료면 메인, 미완료면 온보딩으로 이동
<!-- end of auto-generated comment: release notes by coderabbit.ai -->