### PR TITLE
[#257] 마이) 독서캘린더 문구 api 연결

### DIFF
--- a/src/api/mypage/myReading.ts
+++ b/src/api/mypage/myReading.ts
@@ -1,5 +1,5 @@
 import { privateApi } from "../axiosConfig";
-import type { ReadingCalendarResponse, ReadingCalendarStatusResponse, ReadingStatusResponse } from "../../types/myPage/myReading.types";
+import type { ReadingCalendarResponse, ReadingStatusResponse } from "../../types/myPage/myReading.types";
 
 export const getReadingStatus = async (
   month: string
@@ -18,14 +18,4 @@ export const getReadingCalendar = async (month?: string) => {
     { params: month ? { month } : undefined }
   );
   return data;
-};
-
-
-export const getReadingCalendarSStatus = async (month: string) => {
-  const res = await privateApi.get<{ data: ReadingCalendarStatusResponse }>(
-    `/api/v1/me/reading-status`,
-    { params: { month } }
-  );
-
-  return res.data.data;
 };

--- a/src/components/mypage/CalendarCommentCard.tsx
+++ b/src/components/mypage/CalendarCommentCard.tsx
@@ -1,19 +1,28 @@
-import type { ReadingCalendarStatusResponse } from "../../types/myPage/myReading.types";
+import type { ReadingStatusResponse } from "../../types/myPage/myReading.types";
 
 type CalendarCommentCardProps = {
-  data: ReadingCalendarStatusResponse;
+  data: ReadingStatusResponse;
 };
 
 
 function CalendarCommentCard({ data }: CalendarCommentCardProps) {
   const { aiSummary, dayProgress, progressPercent, month } = data;
+  
+  const monthLabel = (() => {
+    if (!month || typeof month !== 'string') return '?';
+    const match = month.match(/^\d{4}-(\d{1,2})$/);
+    if (!match?.[1]) return '?';
+    const monthNum = parseInt(match[1], 10);
+    return isNaN(monthNum) ? '?' : monthNum;
+  })();
+  
   return (
     <div className="bg-bg">        
       {/* 내용 영역 */}
       <section className="w-full bg-gray-100 rounded-[12px] p-4">
         {/* subitle */}
         <div className="flex justify-between items-center">
-          <div className="w-full text-subtitle-01-sb">{Number(month.split("-")[1])}월의 기록, {progressPercent}%의 몰입</div>
+          <div className="w-full text-subtitle-01-sb">{monthLabel}월의 기록, {progressPercent}%의 몰입</div>
           <div className="text-caption-01 justify-center rounded-full px-3 py-1 h-[25px]">{dayProgress.currentDay}/{dayProgress.lastDay}</div>
         </div>
 

--- a/src/pages/mypage/ReadingCalenderPage.tsx
+++ b/src/pages/mypage/ReadingCalenderPage.tsx
@@ -3,7 +3,7 @@ import { BackIcon } from "../../assets/icons";
 import NavBarTop from "../../components/common/navbar/NavBarTop";
 import CalendarCommentCard from "../../components/mypage/CalendarCommentCard";
 import ReadingCalendar from "../../components/mypage/ReadingCalendar";
-import type { ReadingCalendarStatusResponse } from "../../types/myPage/myReading.types";
+import type { ReadingStatusResponse } from "../../types/myPage/myReading.types";
 import { getReadingStatus } from "../../api/mypage/myReading";
 
 function ReadingCalendarPage() {
@@ -14,7 +14,7 @@ function ReadingCalendarPage() {
   // 기본값: 현재 달
   const [year, setYear] = useState(thisYear);
   const [month, setMonth] = useState(thisMonth);
-  const [status, setStatus] = useState<ReadingCalendarStatusResponse | null>(null);
+  const [status, setStatus] = useState<ReadingStatusResponse | null>(null);
   const [loading, setLoading] = useState(false);
 
 
@@ -34,6 +34,7 @@ function ReadingCalendarPage() {
 
   const handleNextMonth = () => {
     if (isCurrentMonth) return;
+    setLoading(true);
 
     if (month === 12) {
       setYear((prevYear) => prevYear + 1); 
@@ -77,10 +78,6 @@ function ReadingCalendarPage() {
 
       <main className="mt-5 pb-10 px-5">
         <section className="mb-5">
-          {loading && (
-            <div className="h-[88px] bg-gray-100 rounded-[12px] animate-pulse" />
-          )}
-
           {!loading && status && (
             <CalendarCommentCard data={status} />
           )}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #257 

## 📝작업 내용
> 마이) 독서캘린더 문구 api 연결

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* 월간 독서 통계 실시간 표시 - 몰입도 백분율과 일일 진행률이 동적으로 업데이트됩니다
* 월별 독서 기록 데이터 API 연동으로 정확한 통계 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->