### PR TITLE
[#259] 다른 유저 서재 api 연결

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -42,6 +42,7 @@ import Setting from "./pages/mypage/Setting";
 import ReadingCalendarPage from "./pages/mypage/ReadingCalenderPage";
 import ReadingRankingPage from "./pages/mypage/ReadingRankingPage";
 import UserProfilePage from "./pages/mypage/UserProfilePage";
+import UserPublicShelvesPage from "./pages/mypage/UserPublicShelvesPage";
 import { KakaoLoginRedirectPage } from "./pages/KakaoLoginRedirectPage";
 import { FinishedBooksPage } from "./pages/mypage/FinishedBooksPage";
 import { MyBookLogPage } from "./pages/mypage/MyBookLogPage";
@@ -121,6 +122,7 @@ function App() {
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/mypage/editprofile" element={<EditProfile />} />
         <Route path="/users/:userId" element={<UserProfilePage />} />
+        <Route path="/users/:userId/shelves" element={<UserPublicShelvesPage />} />
         <Route path="/setting" element={<Setting />} />
         <Route path="/mypage/readingcalendar" element={<ReadingCalendarPage />} />
         <Route path="/mypage/readingranking" element={<ReadingRankingPage />} />

--- a/src/api/publicUserShelves.ts
+++ b/src/api/publicUserShelves.ts
@@ -2,11 +2,11 @@
 import { privateApi } from "./axiosConfig";
 import type { ResponsePublicUserShelvesDto } from "../types/publicShelves.types";
 
-export function getPublicUserShelvesPreview(userId: number, size = 3) {
+export function getPublicUserShelvesPreview(userId: number, limit = 3) {
   return privateApi.get<ResponsePublicUserShelvesDto>(`/users/${userId}/shelves`, {
     params: {
       visibility: "PUBLIC",
-      size,
+      limit,
     },
   });
 }

--- a/src/hooks/queries/useGetPublicUserShelves.ts
+++ b/src/hooks/queries/useGetPublicUserShelves.ts
@@ -1,0 +1,24 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { QUERY_KEY } from "../../constants/key";
+import { getPublicUserShelves } from "../../api/publicUserShelves";
+
+const PAGE_SIZE = 10;
+
+export function useGetPublicUserShelves(userId?: number) {
+  return useInfiniteQuery({
+    queryKey: [QUERY_KEY.shelves, "public", userId],
+    queryFn: ({ pageParam }) =>
+      getPublicUserShelves(userId as number, { page: pageParam, size: PAGE_SIZE }),
+    initialPageParam: 0,
+    enabled: typeof userId === "number" && Number.isFinite(userId),
+    getNextPageParam: (lastPage, allPages) => {
+      const totalCount = Number(lastPage.data?.totalCount ?? 0);
+      const loadedCount = allPages.reduce(
+        (acc, page) => acc + (page.data?.items?.length ?? 0),
+        0
+      );
+
+      return loadedCount < totalCount ? allPages.length : undefined;
+    },
+  });
+}

--- a/src/pages/mypage/UserProfilePage.tsx
+++ b/src/pages/mypage/UserProfilePage.tsx
@@ -131,7 +131,7 @@ export default function UserProfilePage() {
         const mapped: ShelfSection[] = shelves.map((shelf) => ({
           id: String(shelf.shelfId),
           title: shelf.name,
-          books: (shelf.previewBooks ?? []).map((b) => ({
+          books: (shelf.previewBooks ?? shelf.topBooks ?? []).map((b) => ({
             id: String(b.bookId),
             title: b.title,
             author: b.authorName,
@@ -386,9 +386,7 @@ export default function UserProfilePage() {
                     title={section.title}
                     onViewAll={() => {
                       if (!userId) return;
-                      navigate(`/users/${userId}/library/${section.id}`, {
-                        state: { shelfName: section.title, isPublic: true },
-                      });
+                      navigate(`/users/${userId}/shelves`);
                     }}
                     items={section.books}
                   />
@@ -473,6 +471,7 @@ function ShelfRow<
   items: T[];
 }) {
   const top3 = items.slice(0, 3);
+  const hasBooks = top3.length > 0;
   const GradationFrame =
     "w-[347px] shrink-0 self-stretch rounded-b-[6px] border-[1.2px] border-[rgba(255,255,255,0.7)] bg-[linear-gradient(153deg,rgba(48,73,192,0.28)_18%,rgba(120,138,222,0.28)_44.99%,rgba(120,138,222,0.31)_58.48%,rgba(48,73,192,0.35)_85.47%)] shadow-[0_6px_16px_rgba(48,73,192,0.15)] backdrop-blur-[2px]";
 
@@ -491,49 +490,55 @@ function ShelfRow<
         </button>
       </div>
 
-      <div className="relative flex w-[375px] px-5 flex-col items-center gap-[10px]">
-        <div className="inline-flex items-center gap-[10px]">
-          {top3.map((book) => (
-            <div
-              key={book.id}
-              className="flex w-[104px] h-[156px] items-center rounded-[4px] overflow-hidden bg-[#CDCCCB]"
-            >
-              {book.coverUrl ? (
-                <div
-                  className="h-full w-full bg-center bg-cover"
-                  role="img"
-                  aria-label={book.title}
-                  style={{ backgroundImage: `url(${book.coverUrl})` }}
-                />
-              ) : book.CoverIcon ? (
-                <book.CoverIcon className="h-full w-full" />
-              ) : (
-                <span className="text-xs">No Image</span>
-              )}
-            </div>
-          ))}
-        </div>
+      {hasBooks ? (
+        <div className="relative flex w-[375px] px-5 flex-col items-center gap-[10px]">
+          <div className="inline-flex items-center gap-[10px]">
+            {top3.map((book) => (
+              <div
+                key={book.id}
+                className="flex w-[104px] h-[156px] items-center rounded-[4px] overflow-hidden bg-[#CDCCCB]"
+              >
+                {book.coverUrl ? (
+                  <div
+                    className="h-full w-full bg-center bg-cover"
+                    role="img"
+                    aria-label={book.title}
+                    style={{ backgroundImage: `url(${book.coverUrl})` }}
+                  />
+                ) : book.CoverIcon ? (
+                  <book.CoverIcon className="h-full w-full" />
+                ) : (
+                  <span className="text-xs">No Image</span>
+                )}
+              </div>
+            ))}
+          </div>
 
-        <div className="absolute top-[116px] flex w-[347px] h-[52px] justify-center items-center">
-          <span className={`${GradationFrame}`} />
-        </div>
+          <div className="absolute top-[116px] flex w-[347px] h-[52px] justify-center items-center">
+            <span className={GradationFrame} />
+          </div>
 
-        <div className="flex items-center gap-[10px]">
-          {top3.map((book) => (
-            <div
-              key={`${book.id}-meta`}
-              className="flex w-[104px] flex-col justify-center items-start gap-[2px]"
-            >
-              <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">
-                {book.title}
-              </p>
-              <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">
-                {book.author}, {book.publisher}
-              </p>
-            </div>
-          ))}
+          <div className="flex items-center gap-[10px]">
+            {top3.map((book) => (
+              <div
+                key={`${book.id}-meta`}
+                className="flex w-[104px] flex-col justify-center items-start gap-[2px]"
+              >
+                <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">
+                  {book.title}
+                </p>
+                <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">
+                  {book.author}, {book.publisher}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
-      </div>
+      ) : (
+        <div className="px-5 w-full text-center text-body-03 text-gray-600">
+          서재에 담긴 책이 없습니다.
+        </div>
+      )}
     </section>
   );
 }

--- a/src/pages/mypage/UserPublicShelvesPage.tsx
+++ b/src/pages/mypage/UserPublicShelvesPage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useMemo, useRef } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import NavBarTop from "../../components/common/navbar/NavBarTop";
+import { useGetPublicUserShelves } from "../../hooks/queries/useGetPublicUserShelves";
+
+export default function UserPublicShelvesPage() {
+  const navigate = useNavigate();
+  const { userId } = useParams<{ userId: string }>();
+  const parsedUserId = useMemo(() => {
+    const n = Number(userId);
+    return Number.isFinite(n) ? n : undefined;
+  }, [userId]);
+
+  const {
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isLoading,
+  } = useGetPublicUserShelves(parsedUserId);
+
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+
+  const shelves =
+    data?.pages.flatMap((page) => page.data?.items ?? []).filter(Boolean) ?? [];
+
+  useEffect(() => {
+    if (!bottomRef.current || !hasNextPage) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !isFetchingNextPage) {
+          fetchNextPage();
+        }
+      },
+      { threshold: 0.3 }
+    );
+
+    observer.observe(bottomRef.current);
+
+    return () => observer.disconnect();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, shelves.length]);
+
+  const GradationFrame =
+    "w-[347px] shrink-0 self-stretch rounded-b-[6px] border-[1.2px] border-[rgba(255,255,255,0.7)] bg-[linear-gradient(153deg,rgba(48,73,192,0.28)_18%,rgba(120,138,222,0.28)_44.99%,rgba(120,138,222,0.31)_58.48%,rgba(48,73,192,0.35)_85.47%)] shadow-[0_6px_16px_rgba(48,73,192,0.15)] backdrop-blur-[2px]";
+
+  return (
+    <div className="min-h-screen bg-bg">
+      <NavBarTop title="공개 서재" onBack={() => navigate(-1)} />
+
+      {isLoading && (
+        <div className="px-5 py-12 text-center text-body-03 text-gray-600">
+          서재를 불러오는 중이에요.
+        </div>
+      )}
+
+      {!isLoading && shelves.length === 0 && (
+        <div className="px-5 py-20 text-center">
+          <p className="text-title-02 text-[#262626]">공개된 서재가 없어요.</p>
+          <p className="mt-3 text-body-03 text-[#81807F]">
+            유저가 서재를 공개하면 이곳에서 확인할 수 있어요.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && shelves.length > 0 && (
+        <div className="flex flex-col gap-7 py-6">
+          {shelves.map((shelf) => {
+            const books = (shelf.previewBooks ?? shelf.topBooks ?? []).slice(0, 3);
+
+            return (
+              <section
+                key={shelf.shelfId}
+                className="flex flex-col items-center gap-8 self-stretch"
+              >
+                <div className="flex px-5 justify-between items-center self-stretch">
+                  <p className="text-black text-title-02">{shelf.name}</p>
+                </div>
+
+                {books.length === 0 ? (
+                  <div className="text-center text-body-03 text-gray-600">
+                    서재에 담긴 책이 없습니다.
+                  </div>
+                ) : (
+                  <div className="relative flex w-[375px] px-5 flex-col items-center gap-[10px]">
+                    <div className="inline-flex items-center gap-[10px]">
+                      {books.map((book) => (
+                        <div
+                          key={book.bookId}
+                          className="flex w-[104px] h-[156px] items-center rounded-[4px] overflow-hidden bg-[#CDCCCB]"
+                        >
+                          {book.thumbnailUrl ? (
+                            <img
+                              src={book.thumbnailUrl}
+                              alt={book.title}
+                              className="h-full w-full object-cover"
+                              draggable={false}
+                            />
+                          ) : (
+                            <span className="text-xs">No Image</span>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+
+                    <div className="absolute top-[116px] flex w-[347px] h-[52px] justify-center items-center">
+                      <span className={GradationFrame} />
+                    </div>
+
+                    <div className="flex items-center gap-[10px]">
+                      {books.map((book) => (
+                        <div
+                          key={`${shelf.shelfId}-${book.bookId}`}
+                          className="flex w-[104px] flex-col justify-center items-start gap-[2px]"
+                        >
+                          <p className="line-clamp-1 self-stretch overflow-hidden text-ellipsis text-black text-subtitle-02-sb">
+                            {book.title}
+                          </p>
+                          <p className="w-[105px] line-clamp-1 overflow-hidden text-ellipsis text-gray-500 text-caption-02">
+                            {book.authorName}, {book.publisherName}
+                          </p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </section>
+            );
+          })}
+
+          {isFetchingNextPage && (
+            <div className="px-5 py-4 text-center text-body-03 text-gray-600">
+              더 불러오는 중...
+            </div>
+          )}
+
+          <div ref={bottomRef} className="h-1" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/types/publicShelves.types.ts
+++ b/src/types/publicShelves.types.ts
@@ -14,7 +14,9 @@ export type PublicUserShelf = {
   name: string;
   isPublic: boolean; 
   setOrder: BOOK_ORDER;
-  previewBooks: PublicUserPreviewBook[];
+  previewBooks?: PublicUserPreviewBook[];
+  topBooks?: PublicUserPreviewBook[];
+  bookCount?: number;
 };
 
 export type ResponsePublicUserShelvesDto = {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #259
## 📝작업 내용
> 다른 유저 서재 api

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 사용자의 공개 서재를 확인할 수 있는 새로운 페이지 추가
  * 무한 스크롤로 서재 목록을 편리하게 탐색 가능
  * 서재에 책이 없을 때 안내 메시지 표시
  * 서재 미리보기 책 데이터 원본 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->