### PR TITLE
[#275] 독서 상세정보 페이지 목차 연결

### DIFF
--- a/src/components/home/book/BookInfo.tsx
+++ b/src/components/home/book/BookInfo.tsx
@@ -72,6 +72,28 @@ function BookInfo({ book }: BookInfoProps) {
         </div>
       </section>
 
+      {/* 기본 정보 */}
+      <section>
+        <p className="text-title-02 font-semibold mb-4">기본 정보</p>
+
+        <div className="space-y-2 text-gray-500 text-body-03">
+          <div className="flex">
+            <span className="w-20">출판사</span>
+            <span>{book.publisherName || "-"}</span>
+          </div>
+
+          <div className="flex">
+            <span className="w-20">ISBN</span>
+            <span>{book.isbn13 || book.isbn10 || "-"}</span>
+          </div>
+
+          <div className="flex">
+            <span className="w-20">출판 연도</span>
+            <span>{book.publishedDate?.slice(0, 4) || "-"}</span>
+          </div>
+        </div>
+        </section>
+
     </div>
   );
 }

--- a/src/hooks/useCollapsible.tsx
+++ b/src/hooks/useCollapsible.tsx
@@ -9,11 +9,12 @@ export function useCollapsible(dependency: unknown) {
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+    if (expanded) return;
 
     requestAnimationFrame(() => {
       setCollapsible(el.scrollHeight > el.clientHeight);
     });
-  }, [dependency]);
+  }, [dependency, expanded]);
 
   const toggle = () => setExpanded((prev) => !prev);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
> #275 

## 📝작업 내용
>독서 상세정보 페이지 목차 연결

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 책 소개와 목차의 접기/펼치기 동작을 통합·안정화하여 더 일관된 사용자 경험 제공.
  * 콘텐츠가 영역을 초과할 때만 자동으로 펼침 버튼을 표시하도록 개선.
  * 접힘 상태에서 콘텐츠에 라인 클램프를 적용해 가독성 향상 및 깔끔한 표시 보장.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->