### PR TITLE
[#274] fix: 로그인 페이지 에러 수정

### DIFF
--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -117,11 +117,6 @@ export const AuthProvider = ({ children }: PropsWithChildren) => {
             setAccessToken(accessToken);
             setRefreshToken(refreshToken);
 
-            const myInfo = await getMyProfile();
-            setUserId(myInfo?.userId);
-            setUserIdInStorage(myInfo?.userId);
-            setNickname(myInfo?.nickname);
-            setNicknameInStorage(myInfo?.nickname);
         } catch (error) {
             console.error("토큰 설정 오류", error);
             throw error;

--- a/src/pages/KakaoLoginRedirectPage.tsx
+++ b/src/pages/KakaoLoginRedirectPage.tsx
@@ -1,13 +1,11 @@
 import { useEffect } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
-import { useGetOnboardingProfile } from "../hooks/queries/useGetOnboardingProfile";
 
 export const KakaoLoginRedirectPage = () => {
   const navigate = useNavigate();
   const [params] = useSearchParams();
   const { setTokens } = useAuth();
-  const { refetch } = useGetOnboardingProfile();
 
   useEffect(() => {
     const handleKakaoLogin = async () => {
@@ -21,16 +19,8 @@ export const KakaoLoginRedirectPage = () => {
       }
 
       try {
-
         await setTokens({ accessToken, refreshToken });
-        const { data } = await refetch();
-
-        if (data?.isCompleted) {
-          navigate("/", { replace: true });
-        } else {
-          navigate("/onboarding", { replace: true });
-        }
-
+        navigate("/onboarding", { replace: true });
       } catch (e) {
         console.error("카카오 로그인 처리 실패:", e);
         navigate("/login", { replace: true });
@@ -38,7 +28,7 @@ export const KakaoLoginRedirectPage = () => {
       
     }
     handleKakaoLogin();
-  }, [params, setTokens, navigate, refetch]);
+  }, [params, setTokens, navigate]);
 
   return <div>로그인 처리 중...</div>;
 };

--- a/src/pages/onboarding/LoginPage.tsx
+++ b/src/pages/onboarding/LoginPage.tsx
@@ -4,24 +4,17 @@ import { validateSignin, type UserLoginInformation } from "../../utils/validate"
 import { useAuth } from "../../context/AuthContext";
 import { useEffect, useState } from "react";
 import { KakaoTalk, LogoBooklog, SymbolLogo } from "../../assets/icons";
-import { useGetOnboardingProfile } from "../../hooks/queries/useGetOnboardingProfile";
 
 export const LoginPage = () => {
     const navigate = useNavigate();
     const { login, accessToken } = useAuth();
-    const { data: onboardingProfile, isLoading, isError } = useGetOnboardingProfile();
     const [loginError, setLoginError] = useState<string | null>(null);
 
     useEffect(() => {
-        if (!accessToken) return;
-        if (isLoading) return;
-        if(isError) return;
-        if (onboardingProfile?.isCompleted) {
-            navigate("/", { replace: true });
-        } else {
+        if (accessToken) {
             navigate("/onboarding", { replace: true });
         }
-    }, [accessToken, isLoading, isError, onboardingProfile, navigate,]);
+    }, [accessToken, navigate,]);
 
     const {values, errors, touched, getInputProps} = useForm<UserLoginInformation>({
         initialValue: {

--- a/src/pages/onboarding/OnBoardingPage.tsx
+++ b/src/pages/onboarding/OnBoardingPage.tsx
@@ -6,10 +6,13 @@ import Step3 from "./steps/Step_3_Page";
 import CompletePage from "./steps/CompletePage";
 import { Navigate } from "react-router-dom";
 import { useGetOnboardingProfile } from "../../hooks/queries/useGetOnboardingProfile";
+import { LoadingPage } from "./LoadingPage";
 
 function StepRenderer() {
   const { step } = useOnboarding();
-  const { data } = useGetOnboardingProfile();
+  const { data, isLoading } = useGetOnboardingProfile();
+
+  if (isLoading) return <LoadingPage/>;
 
   if (data?.isCompleted === true) {
     return <Navigate to="/" replace />;


### PR DESCRIPTION
## #️⃣연관된 이슈
> #274

## 📝작업 내용
> 로그인 페이지에서 온보딩 결과 조회 api 삭제
> 소셜 로그인 시 로컬 storage에 userId, nickname 저장 x

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 온보딩 페이지에서 로딩 상태 표시 추가

* **개선 사항**
  * 로그인/온보딩 네비게이션 흐름 간소화
  * 프로필 데이터 페칭 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->