### PR TITLE
[#279] 독서기록 ui 수정

### DIFF
--- a/src/pages/myLibrary/RecordPage.tsx
+++ b/src/pages/myLibrary/RecordPage.tsx
@@ -325,14 +325,15 @@ export default function RecordPage() {
   const [submitting, setSubmitting] = useState(false);
   const submittingRef = useRef(false);
   const isStoppedStatus = status === "중단";
+  const canApplyStopped = isStoppedStatus && hasValidUserBookId;
 
   const canApply = Boolean(
-    (isEditMode || hasValidUserBookId) &&
-      status &&
+    status &&
       !submitting &&
       (
-        isStoppedStatus ||
+        canApplyStopped ||
         (
+          (isEditMode || hasValidUserBookId) &&
           bookType &&
           Number.isFinite(selectedShelfId) &&
           isValidPagesRead &&
@@ -352,7 +353,7 @@ export default function RecordPage() {
     try {
       setSubmitting(true);
 
-      if (isStoppedStatus && hasValidUserBookId && status) {
+      if (canApplyStopped && status) {
         await patchUserBook({
           userBookId: parsedUserBookId,
           body: {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #279

## 📝작업 내용
> 독서기록 ui

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# 릴리스 노트

* **개선사항**
  * "중단" 상태인 도서에 대해 제출 조건을 완화하여 빠르게 상태 변경 및 저장이 가능합니다.
  * 중단 경로에서 변경 시 즉시 저장 후 이전 화면으로 돌아가도록 동작을 단축했습니다.
  * 일반 독서 기록 제출 흐름은 유지하되, 적용 조건을 명확히 분리했습니다.
  * 현재 페이지 입력 필드 라벨을 "현재 페이지 수"로 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->