### PR TITLE
[#302] fix: 북로그 이미지 업로드 api 수정

### DIFF
--- a/src/api/booklogs.ts
+++ b/src/api/booklogs.ts
@@ -13,7 +13,7 @@ export const uploadBooklogImage = async (file: File) => {
   const formData = new FormData();
   formData.append("file", file);
 
-  const res = await privateApi.post<{imageUrl: string;}>("/booklogs/images", formData);
+  const res = await privateApi.post<{imageUrl: string;}>("/booklogs/images", formData, { headers: { "Content-Type": undefined } });
 
   return res.data.imageUrl;
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
> #302

## 📝작업 내용
> 북로그 이미지 업로드 api에서 헤더의 Content-Type 제거

### 스크린샷 (선택)


