### PR TITLE
[#304] refactor: 북로그 작성 페이지 - 기본 책 이미지 불러오기

### DIFF
--- a/src/components/booklog/BookContent.tsx
+++ b/src/components/booklog/BookContent.tsx
@@ -27,7 +27,7 @@ export default function BookContent({
       <img
         className="mx-auto h-[140px] w-[92px] rounded-[4px] bg-[#CDCCCB] grid place-items-center text-caption-01 text-black"
         src={thumbnailUrl}
-        alt="책 img"
+        alt={title}
       />
 
       {/* 책 정보 */}

--- a/src/components/booklog/BookContent.tsx
+++ b/src/components/booklog/BookContent.tsx
@@ -3,6 +3,7 @@ type BookContentProps = {
   author: string;
   publisher?: string;
   tags?: string[]; // ✅ 태그 선택
+  thumbnailUrl?: string;
 };
 
 function TagPill({ children }: { children: React.ReactNode }) {
@@ -18,13 +19,16 @@ export default function BookContent({
   author,
   publisher,
   tags,
+  thumbnailUrl
 }: BookContentProps) {
   return (
     <div className="h-full w-[240px] rounded-[12px] bg-[#EFEDEB] px-[12px] py-[16px]">
       {/* 책 이미지 */}
-      <div className="mx-auto h-[140px] w-[92px] rounded-[4px] bg-[#CDCCCB] grid place-items-center text-caption-01 text-black">
-        책 img
-      </div>
+      <img
+        className="mx-auto h-[140px] w-[92px] rounded-[4px] bg-[#CDCCCB] grid place-items-center text-caption-01 text-black"
+        src={thumbnailUrl}
+        alt="책 img"
+      />
 
       {/* 책 정보 */}
       <div className="mt-2.5 text-center">

--- a/src/components/mypage/MyBookLogCard.tsx
+++ b/src/components/mypage/MyBookLogCard.tsx
@@ -10,7 +10,7 @@ type MyBookCardProps = {
 export const MyBookLogCard = ({ booklog, onClick }: MyBookCardProps) => {
     
     const { mutate: toggleBookmark } = useToggleBooklogBookmark();
-    const bookImage = booklog.book.coverImageUrl ?? "";
+    const bookImage = booklog.book.coverImageUrl;
     const images = (booklog.images ?? []).filter((img) => Boolean(img?.imageUrl));
     const visibleImages = images.slice(0, 2);
     const remainCount = images.length - 1;
@@ -33,6 +33,7 @@ export const MyBookLogCard = ({ booklog, onClick }: MyBookCardProps) => {
                 <img
                     className="flex w-[94px] h-[94px] justify-center items-center rounded-[8px] bg-gray-300"
                     src={bookImage}
+                    alt={booklog.book.title ?? "책 표지"}
                 />
                 {visibleImages.map((img, index) => {
                     if (index === 1 && images.length > 2) {

--- a/src/components/mypage/MyBookLogCard.tsx
+++ b/src/components/mypage/MyBookLogCard.tsx
@@ -10,9 +10,10 @@ type MyBookCardProps = {
 export const MyBookLogCard = ({ booklog, onClick }: MyBookCardProps) => {
     
     const { mutate: toggleBookmark } = useToggleBooklogBookmark();
+    const bookImage = booklog.book.coverImageUrl ?? "";
     const images = (booklog.images ?? []).filter((img) => Boolean(img?.imageUrl));
-    const visibleImages = images.slice(0, 3);
-    const remainCount = images.length - 2;
+    const visibleImages = images.slice(0, 2);
+    const remainCount = images.length - 1;
 
     return (
         <div
@@ -28,11 +29,15 @@ export const MyBookLogCard = ({ booklog, onClick }: MyBookCardProps) => {
                 }
             }}
         >
-            <div className="flex justify-between items-start self-stretch">
+            <div className="flex items-start self-stretch gap-[6.5px]">
+                <img
+                    className="flex w-[94px] h-[94px] justify-center items-center rounded-[8px] bg-gray-300"
+                    src={bookImage}
+                />
                 {visibleImages.map((img, index) => {
-                    if (index === 2 && images.length > 3) {
+                    if (index === 1 && images.length > 2) {
                         return (
-                            <div key={index} className="flex w-[94px] h-[94px] px-[82.276px] py-[43.606px] justify-center items-center gap-[5px] rounded-[6.582px] bg-gray-300">
+                            <div key={index} className="flex w-[94px] h-[94px] justify-center items-center rounded-[6.582px] bg-gray-300">
                                 <p className="[font-feature-settings:'liga'_off] text-black text-en-caption-01">+{remainCount}</p>
                             </div>
                         );

--- a/src/pages/booklog/BookWritePage.tsx
+++ b/src/pages/booklog/BookWritePage.tsx
@@ -322,6 +322,7 @@ export default function BookWritePage() {
               author={authorText}
               publisher={publisherText}
               tags={[]}
+              thumbnailUrl={book?.thumbnailUrl!}
             />
           </div>
         </section>

--- a/src/pages/booklog/BookWritePage.tsx
+++ b/src/pages/booklog/BookWritePage.tsx
@@ -322,7 +322,7 @@ export default function BookWritePage() {
               author={authorText}
               publisher={publisherText}
               tags={[]}
-              thumbnailUrl={book?.thumbnailUrl!}
+              thumbnailUrl={book?.thumbnailUrl as string}
             />
           </div>
         </section>

--- a/src/pages/booklog/BooklogDetailPage.tsx
+++ b/src/pages/booklog/BooklogDetailPage.tsx
@@ -63,6 +63,7 @@ type Post = {
   followedByMe?: boolean;
   images?: { imageId: number; imageUrl: string; order: number }[];
   bookmarkedByMe?: boolean;
+  thumbnailUrl?: string;
 };
 
 function TagPill({ children }: { children: React.ReactNode }) {
@@ -125,6 +126,7 @@ export default function BooklogDetailPage() {
         order: Number(img.order),
       })),
       bookmarkedByMe: detail.bookmarkedByMe,
+      thumbnailUrl: detail.book.coverImageUrl,
     };
   }, [detail]);
 
@@ -245,6 +247,7 @@ export default function BooklogDetailPage() {
         author: `${b.authorName} 저`,
         publisher: b.publisher,
         tags: (b.tags ?? []).map((t) => t.name),
+        coverImageUrl: b.coverImageUrl,
       })),
     [recommendBooks]
   );
@@ -375,6 +378,7 @@ export default function BooklogDetailPage() {
                 title={post.bookTitle}
                 author={post.bookAuthor}
                 publisher={post.publisher}
+                thumbnailUrl={post.thumbnailUrl}
               />
             </div>
 
@@ -477,6 +481,7 @@ export default function BooklogDetailPage() {
                     author={b.author}
                     publisher={b.publisher}
                     tags={b.tags}
+                    thumbnailUrl={b.coverImageUrl}
                   />
                 </div>
               ))}


### PR DESCRIPTION
## #️⃣연관된 이슈
> #304

## 📝작업 내용
> 북로그 작성 페이지 - 기본 책 이미지 불러오기
> 마이 페이지 - 나의 북로그, 북마크한 북로그 이미지 카드 배열 수정

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 책 표지(썸네일)를 책 로그 작성·상세·유사 도서에 표시하도록 추가

* **개선사항**
  * 마이북로그 카드의 이미지 레이아웃 최적화(최대 2개 이미지 표시, 첫 이미지로 도서 표지 노출)
  * 책 로그 관련 화면 전반에서 표지 이미지 흐름 보강 및 표시 일관성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->