### PR TITLE
[#326] fix: 북로그 상제 정보 페이지 - 이미지 안보인 현상 수정

### DIFF
--- a/src/pages/booklog/BooklogDetailPage.tsx
+++ b/src/pages/booklog/BooklogDetailPage.tsx
@@ -382,12 +382,15 @@ export default function BooklogDetailPage() {
               />
             </div>
 
-            {sortedImages[0]?.imageUrl ? (
-              <img
-                src={sortedImages[0].imageUrl}
-                alt=""
-                className="shrink-0 h-[220px] w-[240px] rounded-[12px] object-cover bg-[#6F6F6F] grid place-items-center text-caption-01 text-white/80"
-              />
+            {sortedImages.length > 0 ? (
+              sortedImages.map((img) => (
+                <img
+                  key={img.imageId}
+                  src={img.imageUrl}
+                  alt=""
+                  className="shrink-0 h-[220px] w-[240px] rounded-[12px] object-cover bg-[#6F6F6F]"
+                />
+              ))
             ) : (
               <div className="shrink-0 h-[220px] w-[240px] rounded-[12px] bg-[#6F6F6F] grid place-items-center text-caption-01 text-white/80">
                 사진


### PR DESCRIPTION
## #️⃣연관된 이슈
> #326

## 📝작업 내용
> 북로그 상제 정보 페이지 - 이미지 안보인 현상 수정

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 이미지 표시 기능을 개선했습니다. 이제 첫 번째 이미지만 표시하는 대신 사용 가능한 모든 이미지를 표시합니다.
  * 이미지가 없을 때는 기존 플레이스홀더가 계속 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->