### PR TITLE
[#331] refactor: 온보딩 테스트 문구 추가

### DIFF
--- a/src/data/onboardingTestQuestion.ts
+++ b/src/data/onboardingTestQuestion.ts
@@ -58,6 +58,7 @@ export const ONBOARDING_QUESTION: OnboardingQuestion[] = [
       {
         id: 1,
         key: ["expressionTexture"] as const,
+        label: "표현의 질감",
         options: [
           { label: "담백한", value: "PLAIN", description: "과한 꾸밈없이 진솔하며 매끄럽게 읽히는 문장" },
           { label: "섬세한", value: "DELICATE", description: "세밀한 묘사로 이야기 속 장면의 밀도를 높인 문장"},
@@ -67,6 +68,7 @@ export const ONBOARDING_QUESTION: OnboardingQuestion[] = [
       {
         id: 2,
         key: ["expressionDirection"] as const,
+        label: "표현의 방향",
         options: [
           { label: "직설적", value: "DIRECT", description: "에두르지 않고 사건 본질을 바로 꿰뚫는 문장" },
           { label: "은유적", value: "METAPHORICAL", description: "비유와 상징으로 의미를 전달하는 문장" },


### PR DESCRIPTION
## #️⃣연관된 이슈
> #331

## 📝작업 내용
> 온보딩 테스트 페이지 문구 추가

### 스크린샷 (선택)




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 노트

* **정비 작업**
  * 온보딩 과정의 질문 항목들에 명확한 한국어 레이블이 추가되었습니다. 사용자들이 온보딩을 진행할 때 각 질문의 의도를 더욱 쉽게 이해할 수 있게 되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->